### PR TITLE
Ignore .o files

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -9,3 +9,4 @@
 /tests/Makefile
 /autom4te.cache/
 /configsbox.h
+/*.o


### PR DESCRIPTION
After typing make in src/, I get a lot of .o files lying around and showing up in git status.
This commit marks these files ignored.
