### PR TITLE
Output Network Summary to the selected output file

### DIFF
--- a/src/mbox.c
+++ b/src/mbox.c
@@ -1623,7 +1623,7 @@ cleanup(void)
     }
     if (cflag)
         call_summary(shared_log);
-    sbox_cleanup();
+    sbox_cleanup(shared_log);
 }
 
 static void

--- a/src/sbox.c
+++ b/src/sbox.c
@@ -201,17 +201,17 @@ void sbox_init(void)
     sbox_load_meta();
 }
 
-void sbox_cleanup(void)
+void sbox_cleanup(FILE *outf)
 {
     // dump system-wide logs
     if (systemlog) {
-        fprintf(stderr, "Network Summary:\n");
+        fprintf(outf, "Network Summary:\n");
         // per each process
         struct systemlog *logs;
         for (logs = systemlog; logs != NULL; logs = logs->next) {
             struct auditlog *iter;
             for (iter = logs->logs; iter != NULL; iter = iter->prev) {
-                fprintf(stderr, " > [%d] %s\n", logs->pid, iter->log);
+                fprintf(outf, " > [%d] %s\n", logs->pid, iter->log);
             }
         }
     }
@@ -1427,7 +1427,7 @@ void sbox_stop(struct tcb *tcp, const char *fmt, ...)
     kill_all(tcp);
 
     // clean up & info to user
-    sbox_cleanup();
+    sbox_cleanup(tcp->outf);
     if (opt_interactive) {
         sbox_interactive();
     }

--- a/src/sbox.h
+++ b/src/sbox.h
@@ -16,7 +16,7 @@ extern void sbox_hijack_str(struct tcb *tcp, int arg, char *new);
 extern void sbox_restore_hijack(struct tcb *tcp);
 extern void sbox_check_test_cond(const char *pn, const char *key);
 extern void sbox_init(void);
-extern void sbox_cleanup(void);
+extern void sbox_cleanup(FILE *outf);
 extern int sbox_interactive(void);
 extern void sbox_stop(struct tcb *tcp, const char *fmt, ...);
 extern void sbox_get_readonly_ptr(struct tcb *tcp);


### PR DESCRIPTION
If a file was selected with the -o option, we output the Network Summary
to that file rather than to stderr.
