### PR TITLE
Update readonly_ptr after an execve

### DIFF
--- a/src/sbox.c
+++ b/src/sbox.c
@@ -458,7 +458,8 @@ void sbox_remote_write(struct tcb *tcp, long ptr, char *buf, int len)
         for (i = off; i < 8 - off; i ++) {
             *((char *)&read + i) = buf[i - off];
         }
-        ptrace(PTRACE_POKEDATA, tcp->pid, ptr - off, read, 0);
+        if (ptrace(PTRACE_POKEDATA, tcp->pid, ptr - off, read, 0) < 0)
+            sbox_stop(tcp, "Error writting to %ld", ptr);
 
         len -= 8 - off;
         ptr += 8 - off;
@@ -466,7 +467,8 @@ void sbox_remote_write(struct tcb *tcp, long ptr, char *buf, int len)
     }
 
     for (; len > 0; len -= 8, buf += 8, ptr += 8) {
-        ptrace(PTRACE_POKEDATA, tcp->pid, ptr, *(long *)(buf), 0);
+        if (ptrace(PTRACE_POKEDATA, tcp->pid, ptr, *(long *)(buf), 0) < 0)
+            sbox_stop(tcp, "Error writting to %ld", ptr);
     }
 
     if (len > 0) {
@@ -475,7 +477,8 @@ void sbox_remote_write(struct tcb *tcp, long ptr, char *buf, int len)
         for (i = 0; i < len; i ++) {
             *((char *)&read + i) = buf[i];
         }
-        ptrace(PTRACE_POKEDATA, tcp->pid, ptr, read, 0);
+        if (ptrace(PTRACE_POKEDATA, tcp->pid, ptr, read, 0) < 0)
+            sbox_stop(tcp, "Error writting to %ld", ptr);
     }
 }
 #endif

--- a/src/sbox.c
+++ b/src/sbox.c
@@ -1479,7 +1479,7 @@ void sbox_get_readonly_ptr(struct tcb *tcp)
         int dummy = 0xdeadbeef;
         sbox_remote_write(tcp, ptr, (char *)&dummy, 4);
 
-        long read = ptrace(PTRACE_PEEKDATA, tcp->pid, (char *)ptr, 0);
+        int read = ptrace(PTRACE_PEEKDATA, tcp->pid, (char *)ptr, 0);
         if (read != dummy) {
             dbg(info, "0x%lx is not writable", ptr);
         }

--- a/src/sbox.c
+++ b/src/sbox.c
@@ -1243,6 +1243,16 @@ int sbox_prctl(struct tcb *tcp)
     return 0;
 }
 
+int sbox_execve(struct tcb *tcp)
+{
+    if (entering(tcp)) {
+        sbox_rewrite_path(tcp, AT_FDCWD, 0, READWRITE_READ);
+    } else {
+        sbox_get_readonly_ptr(tcp);
+    }
+    return 0;
+}
+
 DEF_SBOX_SC_PATH_AT(utimensat , 0, 1, WRITE);
 DEF_SBOX_SC_PATH_AT(readlinkat, 0, 1, READ );
 DEF_SBOX_SC_PATH_AT(fchmodat  , 0, 1, WRITE);
@@ -1262,7 +1272,6 @@ DEF_SBOX_SC_PATH(uselib       , 0 , READ );
 DEF_SBOX_SC_PATH(utimes       , 0 , WRITE);
 DEF_SBOX_SC_PATH(utime        , 0 , WRITE);
 DEF_SBOX_SC_PATH(chmod        , 0 , WRITE);
-DEF_SBOX_SC_PATH(execve       , 0 , READ );
 DEF_SBOX_SC_PATH(truncate     , 0 , FORCE);
 DEF_SBOX_SC_PATH(readlink     , 0 , READ );
 DEF_SBOX_SC_PATH(mknod        , 0 , WRITE);


### PR DESCRIPTION
Memory mappings are not preserved after an execve, so readonly_ptr
should be updated.

Also, check the return of ptrace PTRACE_POKEDATA calls, and fix a debug test.
